### PR TITLE
refactoring into low level driver

### DIFF
--- a/lib/roomba/driver.rb
+++ b/lib/roomba/driver.rb
@@ -1,0 +1,35 @@
+class Driver
+
+  include Roomba::Api
+
+  def initialize(serial, latency)
+    @serial, @latency = serial, latency
+  end
+
+
+  private
+  # Change all the arguments to single bytes before writing
+  def write(*args)
+    args.each do |a|
+      @serial.write a.chr
+    end
+  end
+
+  def read(timeout=50)
+    @serial.read_timeout= timeout
+    bytes = []
+    until (x = @serial.getbyte).nil? #read as single bytes
+      bytes.push(x)
+    end
+    bytes
+  end
+
+  # Direct serial cable works fine in my setup with just the
+  # DATA_REFRESH_RATE. However, Bluetooth serial needs
+  # a little extra time between requesting sensor data and
+  # fetching. I set @latency to 0.1 or 0.2 in the initializer
+  # when using Bluetooth.
+  def wait_for_rx
+    sleep DATA_REFRESH_RATE + @latency
+  end 
+end

--- a/lib/roomba/position2d.rb
+++ b/lib/roomba/position2d.rb
@@ -1,0 +1,39 @@
+###########################
+#
+#
+###########################
+class Position2d < Driver
+
+  def drive(velocity,degree)
+    set_velocity(velocity)
+    set_degree(degree)
+    super.drive(@velocity_high, @velocity_low, @radius_high, @radius_low)
+  end
+  
+  def set_degree(degree)
+    if degree == 0
+      mm = 32768
+    elsif degree.abs == 1
+      mm = 1 * (degree <=> 0)
+    else
+      #Roomba will drive on an arc
+      degree = -degree #I want right to be positive and left to be negative :)
+      degree = (180 - degree.abs) * (degree <=> 0)
+      mm = (1.0 / (180.0 / 2000.0)) * degree.to_f
+    end
+
+    @radius_hex = "%04X" % mm.to_i
+    @radius_high = @radius_hex[0..1].to_i(16)#high byte
+    @radius_low = @radius_hex[2..3].to_i(16)#low byte
+  end
+
+  def set_velocity(velocity)
+    if velocity.abs > 500
+      velocity = 500 * (velocity <=> 0)#don't forget the sign
+    end
+    @velocity_hex = ("%04X" % velocity).sub("..","F")[-4,4]#have to remove the leading .. when a two's complement negative is converted to hex
+    @velocity_high = @velocity_hex[0..1].to_i(16)#high byte
+    @velocity_low = @velocity_hex[2..3].to_i(16)#low byte
+  end
+
+end

--- a/lib/roomba/roomba_driver.rb
+++ b/lib/roomba/roomba_driver.rb
@@ -1,0 +1,21 @@
+class RoombaDriver < Driver
+  
+  def start
+    sleep 0.2
+    setup_start
+    sleep 0.1
+    setup_control
+  end
+
+  # wake the Roomba up
+  def wakeup
+    @serial.rts = 0
+    sleep 0.1
+    @serial.rts = 1
+    sleep 2
+    setup_start
+    setup_control
+  end
+
+  
+end

--- a/lib/roomba/sensors.rb
+++ b/lib/roomba/sensors.rb
@@ -1,0 +1,69 @@
+class Sensors
+  
+  def get_readings(*sensors_requested)
+    sensors_requested.collect!{|c| c.to_sym }
+    packet_ids = sensors_requested.map{ |sensor| SENSORS[sensor][:packet] }
+    bytes = querylist(*packet_ids)
+    readings = {}
+    readings[:time] = Time.now.to_i
+    sensors_requested.each do |sensor|
+      readings[sensor] = {:raw => nil, :formatted => []}
+      readings[sensor][:raw] = bytes.shift(SENSORS[sensor][:bytes])
+      readings[sensor][:formatted] = set_readings(sensor, readings[sensor][:raw])
+      puts "Sensors: #{readings[sensor].inspect}"
+    end
+    readings #return hash of readings
+  end
+
+  def set_readings(sensor, readings)
+    readings[0] = 0 if readings[0].nil?
+    if SENSORS[sensor][:bytes] > 1
+      readings[1] = 0 if readings[1].nil?
+    end
+    if SENSORS[sensor][:bits] #return a string representation of the bits
+      return readings.first.to_s(2)
+    elsif !SENSORS[sensor][:signed] && SENSORS[sensor][:bytes] == 1 #return an unsigned integer
+      return readings.first
+    elsif SENSORS[sensor][:signed] && SENSORS[sensor][:bytes] == 1 #return a signed integer
+      return signed_integer(readings)
+    elsif !SENSORS[sensor][:signed] && SENSORS[sensor][:bytes] == 2 #return an unsigned 2 byte integer
+      return readings[0] << 8 | readings[1]
+    else SENSORS[sensor][:signed] && SENSORS[sensor][:bytes] == 2 #return a signed 2 byte integer, twos complement
+      return signed_integer(readings)
+    end
+  end
+
+  # quick report of basic info, should break this out into individual method calls
+  def report
+    sensors = get_readings(:temperature, :oi_mode, :charging_source, :battery_charge, :battery_capacity, :current)
+    sensors[:temperature][:text] = sensors[:temperature][:formatted].to_s + " Celsius"
+    sensors[:battery_charge][:text] = sensors[:battery_charge][:formatted]
+    sensors[:battery_capacity][:text] = sensors[:battery_capacity][:formatted]
+    sensors[:current][:text] = sensors[:current][:formatted].to_s + " mA"
+
+    sensors[:oi_mode][:text] = case sensors[:oi_mode][:formatted]
+    when 0
+      "off"
+    when 1
+      "passive mode"
+    when 2
+      "safe mode"
+    when 3
+      "full mode"
+    end
+
+    sensors[:charging_source][:text] = case sensors[:charging_source][:raw]
+    when 1
+      "charging"
+    when 2
+      "docked"
+    when 3
+      "docked+"
+    else
+      "undocked"
+    end
+
+    sensors
+  end
+
+end


### PR DESCRIPTION
The idea is that those interfaces (roomba, position2d, sensors) do not have any logic inside. The only thing they do is transforming data from one format to another or deal with delays and stuff like that.
You can even make all these classes only one class driver if you prefer.

You may notice that once all this is moved (and the schedule and play and song needs still to be moved) then Roomba does not need to include the Api but it will go to the driver and it does not need to have a serial itself either.

So you may think it will all move to the driver and makes no sense. The only things I think will be saved is the move method because it uses a combination of position and sensors to do something intelligent and the demo1 , motors because also it is much more than just transforming data.

The good part is that roomba class then should be pristine and ready to get new methods with lots of intelligence into them.

Also the simulation would get much more simpler and general as we will not simulate at the binary protocol level but at the level of methods like drive so we can ignore lots of details and do a more generic job.
